### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadRetrieval.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadRetrieval.java
@@ -88,6 +88,7 @@ public class ProfileUploadRetrieval extends AssignmentEndpoint {
     }
     try {
       var id = request.getParameter("id");
+      ensurePathIsRelativeToDest(catPicturesDirectory, (id == null ? RandomUtils.nextInt(1, 11) : id) + ".jpg");
       var catPicture =
           new File(catPicturesDirectory, (id == null ? RandomUtils.nextInt(1, 11) : id) + ".jpg");
 
@@ -112,5 +113,27 @@ public class ProfileUploadRetrieval extends AssignmentEndpoint {
     }
 
     return ResponseEntity.badRequest().build();
+  }
+
+  private static void ensurePathIsRelativeToDest(File dest, String path) {
+    File file = new File(dest, path);
+    String destCanonicalPath;
+    String fileCanonicalPath;
+  
+    try {
+      destCanonicalPath = dest.getCanonicalPath();
+      fileCanonicalPath = file.getCanonicalPath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (!fileCanonicalPath.startsWith(destCanonicalPath + File.separator)) {
+      throw new RuntimeException("Potential directory traversal attempt");
+    }
+  }
+
+
+  private static void ensurePathIsRelativeToDest(String dest, String path) {
+    ensurePathIsRelativeToDest(new File(dest), path);
   }
 }


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Path Traversal** issue reported by **Snyk**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/afc837fb-ecb7-4b3f-9eda-127127cca2c2/project/276cd1ed-64b7-496e-ad14-98eb6f55d5e0/report/8b6bc3ba-7992-4ad5-84be-dc0f410aedaa/fix/3f0e8e2f-72f6-4a7a-9aea-cd7e044a6643)
