### PR TITLE
Zip Slip vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
@@ -70,7 +70,7 @@ public class ProfileZipSlip extends ProfileUploadBase {
       Enumeration<? extends ZipEntry> entries = zip.entries();
       while (entries.hasMoreElements()) {
         ZipEntry e = entries.nextElement();
-        File f = new File(tmpZipDirectory.toFile(), e.getName());
+        File f = new File(tmpZipDirectory.toFile(), getRelativePath(e.getName()));
         InputStream is = zip.getInputStream(e);
         Files.copy(is, f.toPath(), StandardCopyOption.REPLACE_EXISTING);
       }
@@ -78,6 +78,24 @@ public class ProfileZipSlip extends ProfileUploadBase {
       return isSolved(currentImage, getProfilePictureAsBase64());
     } catch (IOException e) {
       return failed(this).output(e.getMessage()).build();
+    }
+  }
+
+  private static String getRelativePath(String path) {
+    String basePath;
+    String filePath;
+  
+    try {
+      basePath = new File(".").getCanonicalPath() + File.separator;
+      filePath = new File(path).getCanonicalPath();
+    } catch (IOException e) {
+      throw new RuntimeException("Potential directory traversal attempt", e);
+    }
+  
+    if (filePath.startsWith(basePath)) {
+      return filePath.substring(basePath.length());
+    } else {
+      throw new RuntimeException("Potential directory traversal attempt");
     }
   }
 


### PR DESCRIPTION
This change fixes a **high severity** (🚩) **Zip Slip** issue reported by **Snyk**.

## Issue description
Zip Slip is a form of directory traversal that can be exploited by extracting files from an archive. Attackers can manipulate archive files to overwrite sensitive files or execute arbitrary code.
 
## Fix instructions
Ensure that extracted files are relative and within the intended directory structure.



[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/afc837fb-ecb7-4b3f-9eda-127127cca2c2/project/276cd1ed-64b7-496e-ad14-98eb6f55d5e0/report/34d9b5f0-664d-49a0-b4ab-aa2753af6580/fix/c312cf65-cb20-4832-b2bf-ebb884504ad1)