### PR TITLE
Value Never Read vulnerability fix (powered by Mobb)

### DIFF
--- a/src/test/java/org/owasp/webgoat/lessons/jwt/TokenTest.java
+++ b/src/test/java/org/owasp/webgoat/lessons/jwt/TokenTest.java
@@ -53,8 +53,7 @@ public class TokenTest {
             .compact();
     log.debug(token);
     Jwt jwt = Jwts.parser().setSigningKey("qwertyqwerty1234").parse(token);
-    jwt =
-        Jwts.parser()
+    Jwts.parser()
             .setSigningKeyResolver(
                 new SigningKeyResolverAdapter() {
                   @Override


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Value Never Read** issue reported by **Sonarqube**.

## Issue description
The variable's value is not used. After the assignment, the variable is either assigned another value or goes out of scope.
 
## Fix instructions
Remove the assignment to the variable.



[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/afc837fb-ecb7-4b3f-9eda-127127cca2c2/project/276cd1ed-64b7-496e-ad14-98eb6f55d5e0/report/2c4acf8d-5c72-45de-96c8-be14174df2af/fix/dab0c81b-385e-4288-8922-758cf181aa0b)