### PR TITLE
Unsafe use of target blank vulnerability fix (powered by Mobb)

### DIFF
--- a/src/main/resources/webgoat/templates/main_new.html
+++ b/src/main/resources/webgoat/templates/main_new.html
@@ -42,7 +42,7 @@
         <!--<div class="user-nav pull-right" id="user-and-info-nav" style="margin-right: 75px;">-->
         <div style="position: absolute;width:400px; z-index:3; top:22px; right: -90px;">
             <!-- webwolf menu item -->
-            <a th:href="@{/WebWolf}" target="_blank">
+            <a th:href="@{/WebWolf}" rel="noopener noreferrer" target="_blank">
                 <button type="button" id="webwolf-button" class="btn btn-default right_nav_button"
                         title="WebWolf">
                     <img th:src="@{/css/img/wolf.svg}"></img>


### PR DESCRIPTION
This change fixes a **low severity** (🟢) **Unsafe use of target blank** issue reported by **Checkmarx**.

## Issue description
Unsafe Target Blank occurs when developers use the target='_blank' attribute without the rel='noopener' attribute in anchor tags. This can lead to security vulnerabilities such as tabnabbing or reverse tabnabbing, allowing attackers to hijack user sessions or perform phishing attacks.
 
## Fix instructions
Ensure that anchor tags with target='_blank' attribute include the rel='noopener' attribute to prevent potential security vulnerabilities. This prevents the newly opened page from accessing the window.opener property, mitigating the risk of tabnabbing or reverse tabnabbing attacks.



[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/afc837fb-ecb7-4b3f-9eda-127127cca2c2/project/276cd1ed-64b7-496e-ad14-98eb6f55d5e0/report/fd7337fa-f42c-4e7c-9442-e7d3a4843f1f/fix/3215759e-93b8-44cc-ae03-be8c2ee879ae)